### PR TITLE
Script to utilize python2 via docker to run scripts.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+# Running via Docker
+
+If you don't have an up-and-running `python` environment (especially the retired `python 2.7` and earlier), but you DO have access to `dokcer`, the scripts in this dir can help you run Mastermind API Cookbook tools in a transient docker container.
+
+

--- a/docker/python2.sh
+++ b/docker/python2.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# (sets $HERE to this dir)
+pushd `dirname ${BASH_SOURCE[0]}` > /dev/null; HERE=`pwd`; popd > /dev/null
+
+# mastermind-api-cookbook dir to mount in the container:
+cookbook="$HERE/.."
+
+# get the script name
+pyscript=$1
+shift
+
+# Use python2 image from docker hub
+docker_img="qzkc/python2.7:v2"
+
+# Run python in the container, with whatever args.
+# !! NB !! ANY FILENAMES PASSED AS ARGS NEED TO BE PREFIXED WITH /data/ SO THE SCRIPT CAN FIND THEM IN THE CONTAINER
+docker run -v "${cookbook}":/data --rm ${docker_img} python data/${pyscript} $@
+


### PR DESCRIPTION
I made this because my box struggles with python 2 and pip et al (I biased the system toward python 3)... this script lets you run python2 in a container.  It may or may not be public-appropriate; if not, let's not merge.